### PR TITLE
Fix type name for DebateInfo component

### DIFF
--- a/src/components/debate/debate-info.tsx
+++ b/src/components/debate/debate-info.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-type DebateInforops = {
+type DebateInfoProps = {
   author?: string | null;
   createdAt: string;
   deadline: string;
@@ -16,7 +16,7 @@ export const DebateInfo = ({
   category,
   views,
   comments,
-}: DebateInforops) => (
+}: DebateInfoProps) => (
   <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-500">
     {author && <span>작성자 · {author}</span>}
     <span>생성 · {dayjs(createdAt).format('YYYY-MM-DD')}</span>


### PR DESCRIPTION
## Summary
- rename `DebateInforops` to `DebateInfoProps`
- update `DebateInfo` to use the new prop type

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*