### PR TITLE
Fix sidebar type import

### DIFF
--- a/src/types/debate.type.ts
+++ b/src/types/debate.type.ts
@@ -1,5 +1,4 @@
 import {
-  DebateSidebarItem,
   DebateList,
   DebateDetail,
   CreateDebateBody,
@@ -9,7 +8,6 @@ import { z } from 'zod';
 
 export type SortType = 'hot' | 'imminent' | 'latest';
 
-export type TSidebarItem = z.infer<typeof DebateSidebarItem>;
 export type TDebateList = z.infer<typeof DebateList>;
 export type TDebateDetail = z.infer<typeof DebateDetail>;
 export type TCreateDebate = z.infer<typeof CreateDebateBody>;


### PR DESCRIPTION
## Summary
- remove unused `DebateSidebarItem` type and import

## Testing
- `pnpm build` *(fails: connect EHOSTUNREACH)*
- `pnpm lint` *(fails: connect EHOSTUNREACH)*