### PR TITLE
Fix query client usage

### DIFF
--- a/src/services/comment.query.ts
+++ b/src/services/comment.query.ts
@@ -1,13 +1,12 @@
 import {
   useInfiniteQuery,
   useMutation,
-  QueryClient,
+  useQueryClient,
 } from '@tanstack/react-query';
 import { fetchComments, addComment } from './comment.service';
 import { QUERY_KEY } from '@/lib/query/query-key';
 import { CommentListDto } from '@/schemas/comment.schema';
 
-const qc = new QueryClient();
 
 export function useComments(debateId: string, side: 'PRO' | 'CON', limit = 20) {
   return useInfiniteQuery({
@@ -27,11 +26,15 @@ export function useComments(debateId: string, side: 'PRO' | 'CON', limit = 20) {
 }
 
 export function useAddComment() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: addComment,
     onSuccess: (_res, variables) => {
-      qc.invalidateQueries({
-        queryKey: QUERY_KEY.COMMENT.ALL(variables.debateId, variables.side),
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.COMMENT.ALL(
+          variables.debateId,
+          variables.side,
+        ),
       });
     },
   });

--- a/src/services/debate.query.ts
+++ b/src/services/debate.query.ts
@@ -3,12 +3,11 @@ import { SortType, TDebateDetail } from '@/types/debate.type';
 import {
   useInfiniteQuery,
   useMutation,
-  QueryClient,
   useSuspenseQuery,
+  useQueryClient,
 } from '@tanstack/react-query';
 import { createDebate, fetchDebate, fetchDebates } from './debate.service';
 
-const queryClient = new QueryClient();
 
 export function useInfiniteDebates(sort: SortType, limit: number = 10) {
   return useInfiniteQuery({
@@ -35,6 +34,7 @@ export function useDebate(id: string) {
 }
 
 export function useCreateDebate() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createDebate,
     onSuccess: () =>


### PR DESCRIPTION
## Summary
- drop custom QueryClient instances
- use `useQueryClient` hook for updates

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.6.5.tgz)*
- `npx next lint` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*